### PR TITLE
Twogather web backend 51

### DIFF
--- a/src/main/java/com/twogather/twogatherwebbackend/service/MemberService.java
+++ b/src/main/java/com/twogather/twogatherwebbackend/service/MemberService.java
@@ -47,6 +47,9 @@ public class MemberService {
         );
         return passwordEncoder.matches(password, member.getPassword());
     }
+    public boolean existsEmail(String email){
+        return memberRepository.findActiveMemberByEmail(email).isPresent();
+    }
 
     private MemberResponse toResponse(Member member){
         return new MemberResponse(member.getMemberId(), member.getUsername(),member.getEmail(),member.getName());

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,1 @@
-spring.profiles.active=prod
+spring.profiles.active=dev

--- a/src/test/java/com/twogather/twogatherwebbackend/acceptance/MemberAcceptanceTest.java
+++ b/src/test/java/com/twogather/twogatherwebbackend/acceptance/MemberAcceptanceTest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.twogather.twogatherwebbackend.domain.Member;
 import com.twogather.twogatherwebbackend.dto.Response;
+import com.twogather.twogatherwebbackend.dto.email.EmailRequest;
 import com.twogather.twogatherwebbackend.dto.member.LoginRequest;
 import com.twogather.twogatherwebbackend.dto.member.MemberResponse;
 import com.twogather.twogatherwebbackend.dto.member.MemberSaveUpdateRequest;
@@ -192,6 +193,18 @@ public class MemberAcceptanceTest extends AcceptanceTest{
         //then
         failLogin(CONSUMER_LOGIN_REQUEST)
                 .statusCode(HttpStatus.UNAUTHORIZED.value());
+    }
+
+    @Test
+    @DisplayName("이미 존재하는 회원의 email로 email 검증 시도 시 throw exception")
+    public void whenSendMailWithDuplicateEmail_ThenThrowException(){
+        //given
+        registerConsumer();
+        //when,then
+        String url = "/api/email";
+        doPost(url, new EmailRequest(CONSUMER_EMAIL))
+                .statusCode(HttpStatus.BAD_REQUEST.value())
+                .body("message", equalTo(DUPLICATE_EMAIL.getMessage()));
     }
 
     private <T> MemberResponse updateMember(String url, String refreshToken, String accessToken, T request){


### PR DESCRIPTION
- type: `feat`
- 이메일 전송 api에서 이메일이 이미 존재할 경우 예외를 터뜨리는 로직 추가
- #51